### PR TITLE
ci: use node 20 and 22 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,7 +24,7 @@ jobs:
       - name: Test
         run: npm test
       - name: Report Coverage
-        if: ${{ matrix.node-version == 18 }}
+        if: ${{ matrix.node-version == 22 }}
         run: |
           curl -sL https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' # only on success
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary

Update node versions in GitHub Actions from 16 and 18 to 20 and 22

## Issues Resolved

None

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] New code complies with `prettier` formatting rules
- [x] New code passes `ts-standard` linting
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
