### PR TITLE
fix: force release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/ac7dbc9a2d5e0bf8bd7d/test_coverage)](https://codeclimate.com/github/aensley/semantic-release-openapi/test_coverage)
 [![npm downloads](https://img.shields.io/npm/dw/@aensley/semantic-release-openapi)][npm]
 
-A Semantic Release plugin to update versions in OpenAPI specifications.
+A Semantic Release plugin to update versions in OpenAPI / Swagger specification files.
 
 ## Installation
 
@@ -27,7 +27,7 @@ npm install --save-dev @aensley/semantic-release-openapi
 
 This plugin has one configuration option which must be supplied.
 
-- **`apiSpecFiles`**: An array of OpenAPI specification file paths. [Glob patterns](https://www.npmjs.com/package/glob) (e.g. `'*.yaml'`) are supported.
+- **`apiSpecFiles`**: An array of OpenAPI / Swagger specification file paths. [Glob patterns](https://www.npmjs.com/package/glob) (e.g. `'*.yaml'`) are supported.
 
   _All matching files must have a `.json`, `.yaml`, or `.yml` extension._
 


### PR DESCRIPTION
## Summary

Force release

## Issues Resolved

#32 should have triggered a release.

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] New code complies with `prettier` formatting rules
- [x] New code passes `ts-standard` linting
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
