### PR TITLE
fix: put compiled javascript directly under dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,14 +9,14 @@
     "esModuleInterop": true,
     "strictNullChecks": true,
     "moduleResolution": "node",
-    "typeRoots": ["./node_modules/@types", "./src/@types"],
+    "typeRoots": ["node_modules/@types", "src/@types"],
     "types": ["node", "jest"],
     "outDir": "dist",
-    "rootDir": ".",
+    "rootDir": "src",
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["./src/**/*", "./test/**/*"],
-  "exclude": ["./node_modules/**/*", "./dist/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules/**/*", "dist/**/*", "test/**/*", "coverage/**/*"]
 }


### PR DESCRIPTION
## Summary

Fix tsconfig so that compiled javascript src is placed directly under `/dist/`; not `/dist/src/`.

## Issues Resolved

Fixes #35 

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] New code complies with `prettier` formatting rules
- [x] New code passes `ts-standard` linting
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
