### PR TITLE
fix: remove tsconfig.json from files declared in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "files": [
     "dist/**/*",
     "src/**/*",
-    "tsconfig.json",
     "README.md",
     "package.json"
   ],


### PR DESCRIPTION
## Summary

Remove tsconfig.json from `files` declared in package.json

## Issues Resolved

Fixes #41 

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] New code complies with `prettier` formatting rules
- [x] New code passes `ts-standard` linting
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
