### PR TITLE
fix: remove clean step from pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "scripts": {
     "pre-commit-msg": "echo Running pre-commit checks...",
     "build": "tsc --build",
-    "clean": "tsc --build --clean",
     "format": "prettier --write .",
     "test": "ts-standard && prettier --check . && jest --coverage --verbose",
     "lint": "ts-standard && prettier --check .",
@@ -83,7 +82,6 @@
   "pre-commit": {
     "run": [
       "pre-commit-msg",
-      "clean",
       "test"
     ],
     "silent": true,


### PR DESCRIPTION
## Summary

Remove the `clean` step from `pre-commit` hook. This inadvertently deletes the contents of the `dist/` folder before semantic-release is run.

## Issues Resolved

None.

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
