### PR TITLE
fix: fix file resolution for apiSpecFiles field

### DIFF
--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -19,7 +19,7 @@ const prepareApiSpecFiles = async (apiSpecFiles: string[], version: string, logg
   try {
     for (const fileNameGlob of apiSpecFiles) {
       // eslint-disable-next-line new-cap
-      const fileNames: string[] = new fdir().withRelativePaths().glob(fileNameGlob).crawl('.').sync()
+      const fileNames: string[] = new fdir().glob(fileNameGlob).withBasePath().crawl('.').sync()
       for (const fileName of fileNames) {
         let results: string[]
         if (fileName.split('.').pop() === 'json') {

--- a/src/verifyConditions.ts
+++ b/src/verifyConditions.ts
@@ -18,7 +18,7 @@ export default async function ({ apiSpecFiles }: PluginConfig): Promise<any> {
   let specFilesFound: boolean = false
   apiSpecFiles.forEach((fileNameGlob: string) => {
     // eslint-disable-next-line new-cap
-    const fileNames: string[] = new fdir().glob(fileNameGlob).crawl('.').sync()
+    const fileNames: string[] = new fdir().glob(fileNameGlob).withBasePath().crawl('.').sync()
     if (fileNames.length > 0) {
       specFilesFound = true
       fileNames.forEach((fileName: string) => {

--- a/test/prepare.test.ts
+++ b/test/prepare.test.ts
@@ -25,7 +25,7 @@ const { readJsonSync, writeJsonSync } = fsExtra
 let mockFiles: string[] = []
 jest.mock('fdir', () => {
   class fdirMock {
-    withRelativePaths() {
+    withBasePath() {
       return this
     }
     glob() {

--- a/test/verifyConditions.test.ts
+++ b/test/verifyConditions.test.ts
@@ -26,6 +26,9 @@ import { verifyConditions } from '../src/index.js'
 let mockFiles: string[] = []
 jest.mock('fdir', () => {
   class fdirMock {
+    withBasePath() {
+      return this
+    }
     glob() {
       return this
     }


### PR DESCRIPTION
## Summary

Fixes file resolution issues for `apiSpecFiles` by replacing `withRelativePaths()` with `withBasePath()`.  
This change ensures that files in nested directories are correctly resolved and updated.

## Issues Resolved

None

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests  
- [x] `npm test` passes  
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)

