### PR TITLE
feat(package): transform to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "email": "aensley@users.noreply.github.com",
     "url": "https://andrewensley.com"
   },
+  "type": "module",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/aensley/semantic-release-openapi/issues/new?template=bug-report.yml"
@@ -46,7 +47,7 @@
     "pre-commit-msg": "echo Running pre-commit checks...",
     "pre-publish": "npm run build && npm run packito && cp README.md dist/ && cp LICENSE dist/",
     "setup": "npm install && npm run prepare-hook",
-    "test": "npm run lint && jest --coverage --verbose",
+    "test": "npm run lint && NODE_OPTIONS=--experimental-vm-modules jest --coverage --verbose",
     "update": "npx npm-check-updates -u && npm update"
   },
   "pre-commit": {
@@ -153,14 +154,21 @@
   },
   "jest": {
     "clearMocks": true,
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
     "testEnvironment": "node",
     "transform": {
       "^.+\\.[jt]s$": [
         "ts-jest",
         {
-          "tsconfig": "tsconfig.test.json"
+          "tsconfig": "tsconfig.test.json",
+          "useESM": true
         }
       ]
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!(@semantic-release/error|glob|replace-in-file)/)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as verifyConditions } from './verifyConditions'
-export { default as prepare } from './prepare'
+export { default as verifyConditions } from './verifyConditions.js'
+export { default as prepare } from './prepare.js'

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -1,8 +1,8 @@
 import SemanticReleaseError from '@semantic-release/error'
 import { readJsonSync, writeJsonSync } from 'fs-extra'
-import replace from 'replace-in-file'
+import { replaceInFileSync } from 'replace-in-file'
 import { PrepareContext } from 'semantic-release'
-import PluginConfig from './@types/pluginConfig'
+import PluginConfig from './@types/pluginConfig.js'
 import { globSync } from 'glob'
 
 /**
@@ -44,12 +44,11 @@ const prepareApiSpecFiles = (apiSpecFiles: string[], version: string, logger: Pr
  * @returns {string[]} A list of altered files
  */
 const prepareApiSpecFileYml = (apiSpecFile: string, version: string): string[] => {
-  const changedFiles = replace
-    .replaceInFileSync({
-      files: apiSpecFile,
-      from: /version: ?.+$/im,
-      to: 'version: ' + version
-    })
+  const changedFiles = replaceInFileSync({
+    files: apiSpecFile,
+    from: /version: ?.+$/im,
+    to: 'version: ' + version
+  })
     .filter((result) => result.hasChanged)
     .map((result) => result.file)
   return changedFiles

--- a/src/verifyConditions.ts
+++ b/src/verifyConditions.ts
@@ -1,6 +1,6 @@
 import SemanticReleaseError from '@semantic-release/error'
 import { globSync } from 'glob'
-import PluginConfig from './@types/pluginConfig'
+import PluginConfig from './@types/pluginConfig.js'
 
 /**
  * verifyConditions hook for semantic release

--- a/test/prepare.test.ts
+++ b/test/prepare.test.ts
@@ -2,20 +2,25 @@
  * Test prepare
  */
 
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 import SemanticReleaseError from '@semantic-release/error'
-import { readJsonSync, writeJsonSync } from 'fs-extra'
-import { replaceInFileSync } from 'replace-in-file'
 import type { PrepareContext } from 'semantic-release'
-import prepare from '../src/prepare'
-import { globSync } from 'glob'
 
-jest.mock('fs-extra')
-jest.mock('replace-in-file', () => ({
+jest.unstable_mockModule('fs-extra', () => ({
+  readJsonSync: jest.fn(),
+  writeJsonSync: jest.fn()
+}))
+jest.unstable_mockModule('replace-in-file', () => ({
   replaceInFileSync: jest.fn()
 }))
-jest.mock('glob', () => ({
+jest.unstable_mockModule('glob', () => ({
   globSync: jest.fn()
 }))
+
+const { default: prepare } = await import('../src/prepare.js')
+const { readJsonSync, writeJsonSync } = await import('fs-extra')
+const { replaceInFileSync } = await import('replace-in-file')
+const { globSync } = await import('glob')
 
 const logger = {
   log: jest.fn(),
@@ -38,7 +43,7 @@ const yamlFilePath = 'test/data/openapi.yaml'
 describe('prepare', () => {
   beforeEach(() => {
     // Always pretend every file given exists.
-    ;(globSync as unknown as jest.Mock).mockImplementation((value: string) => {
+    ;(globSync as unknown as jest.Mock).mockImplementation((value: unknown) => {
       return [value]
     })
   })

--- a/test/verifyConditions.test.ts
+++ b/test/verifyConditions.test.ts
@@ -2,18 +2,19 @@
  * Test verifyConditions
  */
 
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 import SemanticReleaseError from '@semantic-release/error'
-import verifyConditons from '../src/verifyConditions'
-import { globSync } from 'glob'
 
-jest.mock('glob', () => ({
+jest.unstable_mockModule('glob', () => ({
   globSync: jest.fn()
 }))
 
+const { default: verifyConditions } = await import('../src/verifyConditions.js')
+const { globSync } = await import('glob')
+
 describe('verifyConditions', () => {
   beforeEach(() => {
-    // Always pretend every file given exists.
-    ;(globSync as unknown as jest.Mock).mockImplementation((value: string) => {
+    ;(globSync as unknown as jest.Mock).mockImplementation((value: unknown) => {
       return [value]
     })
   })
@@ -22,7 +23,7 @@ describe('verifyConditions', () => {
     it('errors if there are no paths provided', async () => {
       expect.assertions(1) // Fail if there is no error caught.
       try {
-        await verifyConditons({ apiSpecFiles: [] })
+        await verifyConditions({ apiSpecFiles: [] })
       } catch (e) {
         expect(e).toEqual(
           new SemanticReleaseError(
@@ -34,12 +35,12 @@ describe('verifyConditions', () => {
     })
 
     it('errors if none of the paths exist', async () => {
-      ;(globSync as unknown as jest.Mock).mockImplementation((value: string) => {
+      ;(globSync as unknown as jest.Mock).mockImplementation(() => {
         return []
       })
       expect.assertions(1) // Fail if there is no error caught.
       try {
-        await verifyConditons({ apiSpecFiles: ['does-not-exist.yml'] })
+        await verifyConditions({ apiSpecFiles: ['does-not-exist.yml'] })
       } catch (e) {
         expect(e).toEqual(
           new SemanticReleaseError(
@@ -53,7 +54,7 @@ describe('verifyConditions', () => {
     it('errors if any of the paths has an invalid extension', async () => {
       expect.assertions(1) // Fail if there is no error caught.
       try {
-        await verifyConditons({ apiSpecFiles: ['test/data/exists-but-invalid-extension.wrong'] })
+        await verifyConditions({ apiSpecFiles: ['test/data/exists-but-invalid-extension.wrong'] })
       } catch (e) {
         expect(e).toEqual(
           new SemanticReleaseError(


### PR DESCRIPTION
## Summary

Update package structure to use ESM universally instead of CommonJS

## Issues Resolved

Fixes #78

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
