### PR TITLE
fix(ci): resolve release pre-commit linting error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+
+version: 2
+updates:
+- package-ecosystem: "npm" # See documentation for possible values
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
-        run: npm ci
+        # Don't run post-install scripts which set the pre-commit hooks
+        # pre-commit hooks run npm test, which is already run by pre-publish below
+        run: npm ci --ignore-scripts
       - name: Pre-Publish (Build, Test, Packito)
         run: npm run pre-publish
       - name: Release

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 [![standard](https://img.shields.io/badge/standard-f3df49.svg?logo=standardjs&logoColor=000)](https://standardjs.com/)
 [![bundle size](https://img.shields.io/bundlephobia/min/semantic-release-openapi.svg?label=size)](https://bundlephobia.com/package/semantic-release-openapi)
 [![npm downloads](https://img.shields.io/npm/dw/semantic-release-openapi.svg)][npm]
-[![dependencies](https://img.shields.io/librariesio/release/npm/semantic-release-openapi)](https://libraries.io/npm/semantic-release-openapi)<br>
+[![Dependabot badge](https://badgen.net/github/dependabot/aensley/semantic-release-openapi?icon=dependabot)](https://github.com/aensley/semantic-release-openapi/security/dependabot)<br>
 [![Maintainability](https://qlty.sh/gh/aensley/projects/semantic-release-openapi/maintainability.svg)][qltysh]
 [![Test Coverage](https://qlty.sh/gh/aensley/projects/semantic-release-openapi/coverage.svg)][qltysh]
 [![test](https://github.com/aensley/semantic-release-openapi/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/aensley/semantic-release-openapi/actions/workflows/test.yml)
-[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/aensley/semantic-release-openapi.svg?label=ossf%20score)](https://scorecard.dev/viewer/?uri=github.com/aensley/semantic-release-openapi)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/aensley/semantic-release-openapi.svg?label=ossf)](https://scorecard.dev/viewer/?uri=github.com/aensley/semantic-release-openapi)
 [![Socket](https://socket.dev/api/badge/npm/package/semantic-release-openapi)](https://socket.dev/npm/package/semantic-release-openapi)
 [![snyk](https://snyk.io/test/npm/semantic-release-openapi/badge.svg)](https://security.snyk.io/package/npm/semantic-release-openapi)
+[![dependencies](https://img.shields.io/librariesio/release/npm/semantic-release-openapi.svg?label=deps)](https://libraries.io/npm/semantic-release-openapi)
 
 A Semantic Release plugin to update versions in OpenAPI / Swagger specification files.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@
 [![prettier](https://img.shields.io/badge/prettier-ff69b4.svg?&logo=prettier&logoColor=fff)](https://prettier.io/)
 [![standard](https://img.shields.io/badge/standard-f3df49.svg?logo=standardjs&logoColor=000)](https://standardjs.com/)
 [![bundle size](https://img.shields.io/bundlephobia/min/semantic-release-openapi.svg?label=size)](https://bundlephobia.com/package/semantic-release-openapi)
-[![npm downloads](https://img.shields.io/npm/dw/semantic-release-openapi.svg)][npm]<br>
+[![npm downloads](https://img.shields.io/npm/dw/semantic-release-openapi.svg)][npm]
+[![dependencies](https://img.shields.io/librariesio/release/npm/semantic-release-openapi)](https://libraries.io/npm/semantic-release-openapi)<br>
 [![Maintainability](https://qlty.sh/gh/aensley/projects/semantic-release-openapi/maintainability.svg)][qltysh]
 [![Test Coverage](https://qlty.sh/gh/aensley/projects/semantic-release-openapi/coverage.svg)][qltysh]
 [![test](https://github.com/aensley/semantic-release-openapi/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/aensley/semantic-release-openapi/actions/workflows/test.yml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/aensley/semantic-release-openapi.svg?label=ossf%20score)](https://scorecard.dev/viewer/?uri=github.com/aensley/semantic-release-openapi)
+[![Socket](https://socket.dev/api/badge/npm/package/semantic-release-openapi)](https://socket.dev/npm/package/semantic-release-openapi)
+[![snyk](https://snyk.io/test/npm/semantic-release-openapi/badge.svg)](https://security.snyk.io/package/npm/semantic-release-openapi)
 
 A Semantic Release plugin to update versions in OpenAPI / Swagger specification files.
 


### PR DESCRIPTION
## Summary

prevent npm ci from running post-install scripts which create the pre-commit hook

## Issues Resolved

None.

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
