### PR TITLE
ci(release): :ferris_wheel: use node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     strategy:
       matrix:
-        node-version: [26]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Revert to node 22 for Semantic-release

## Issues Resolved

None.

## Checklist before requesting a review

- [x] New code (`src/*`) has corresponding unit tests
- [x] `npm test` passes
- [x] I agree to the [Contributing guidelines](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/aensley/semantic-release-openapi/blob/main/.github/CODE_OF_CONDUCT.md)
